### PR TITLE
Add model metadata inspector tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `comfywatchman inspect` command for deterministic model metadata summaries
+- `comfyfixersmart.inspector` library module with safe inspection APIs
+- Usage guide at `docs/usage/inspect.md`
 - Comprehensive documentation structure in `docs/` directory
 - User guides, developer documentation, and API reference
 - Performance optimization guides and troubleshooting documentation

--- a/docs/usage/inspect.md
+++ b/docs/usage/inspect.md
@@ -1,0 +1,80 @@
+# Inspecting Model Metadata
+
+The `inspect` command provides a deterministic way to summarise ComfyUI model
+assets without loading large tensors. It is intended for quick, offline
+metadata checks and for scripting model inventories.
+
+## Basic usage
+
+Run the inspector against a single file to print a concise text summary:
+
+```bash
+comfywatchman inspect /path/to/model.safetensors
+```
+
+Use JSON when you want structured output:
+
+```bash
+comfywatchman inspect /path/to/model.ckpt --format json
+```
+
+Multiple paths are supported and traversal order is deterministic. Directories
+are scanned non-recursively by default. Enable recursion with:
+
+```bash
+comfywatchman inspect /path/to/models --recursive
+```
+
+## Recognised formats
+
+- `.safetensors` – reads header metadata only via `safetensors.safe_open()`.
+- `.ckpt`, `.pt`, `.pth`, `.bin` – **unsafe loading is disabled by default.**
+  Pass `--unsafe` to opt-in to `torch.load(..., map_location="cpu")` for a
+  shallow summary of top-level keys.
+- `.onnx` – reports IR version, opsets, and producer metadata when the `onnx`
+  package is installed.
+- Diffusers directories (containing `model_index.json`) – summarised at the
+  directory level with pipeline class and component stubs.
+- Other extensions are treated as `format="other"` with a warning.
+
+## Safety defaults
+
+- Unsafe operations (pickle loading) are **opt-in** via `--unsafe`.
+- Hashing is optional (`--hash`) and can be slow on large files.
+- Diffusers component listings can be disabled with `--no-components`.
+- Outputs are deterministic: traversal and JSON key ordering are stable, and
+  no timestamps are included.
+
+## Example commands
+
+```bash
+# Inspect a LoRA safetensors file with metadata keys
+comfywatchman inspect path/to/lora.safetensors
+
+# Emit JSON for automation
+comfywatchman inspect path/to/model.pth --format json
+
+# Summarise an ONNX model (requires the onnx extra)
+comfywatchman inspect path/to/clip.onnx
+
+# Review a Diffusers pipeline
+comfywatchman inspect path/to/diffusers_repo --no-components
+
+# IP-Adapter .bin file with opt-in unsafe metadata (requires torch)
+comfywatchman inspect path/to/ip-adapter.bin --unsafe
+```
+
+## Library usage
+
+The inspector can be used directly from Python:
+
+```python
+from comfyfixersmart.inspector import inspect_file, inspect_paths
+
+summary = inspect_file("model.safetensors")
+bulk = inspect_paths(["model.safetensors", "models/"], fmt="json", recursive=True)
+```
+
+Both functions avoid loading tensors and return deterministic dictionaries that
+can be safely logged or serialised.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,12 @@ full = [
     "aiohttp>=3.8.0",
     "httpx>=0.24.0",
     "modelscope>=1.28.0",
+    "safetensors>=0.4.2",
+    "onnx>=1.14.0",
+]
+inspector = [
+    "safetensors>=0.4.2",
+    "onnx>=1.14.0",
 ]
 
 [project.urls]

--- a/src/comfyfixersmart/cli.py
+++ b/src/comfyfixersmart/cli.py
@@ -1,10 +1,7 @@
-"""
-Command Line Interface for ComfyFixerSmart
-
-Provides CLI entry points for running ComfyFixerSmart from the command line.
-"""
+"""Command Line Interface for ComfyFixerSmart."""
 
 import argparse
+import json
 import sys
 from pathlib import Path
 from typing import List, Optional
@@ -17,106 +14,164 @@ from .core import run_comfy_fixer, run_v1_compatibility_mode, run_v2_compatibili
 def create_parser() -> argparse.ArgumentParser:
     """Create the main argument parser."""
     parser = argparse.ArgumentParser(
-        prog="comfyfixer",
+        prog="comfywatchman",
         description="ComfyFixerSmart - Incremental ComfyUI model downloader",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  comfyfixer                          # Analyze all workflows in default directories
-  comfyfixer workflow.json            # Analyze specific workflow file
-  comfyfixer --dir /path/to/workflows  # Analyze workflows in specific directory
-  comfyfixer --search civitai,huggingface  # Use specific search backends
-  comfyfixer --v1                      # Use v1 compatibility mode
-  comfyfixer --v2                      # Use v2 compatibility mode (default)
-        """
+  comfywatchman                          # Analyze all workflows in default directories
+  comfywatchman workflow.json            # Analyze specific workflow file
+  comfywatchman --dir /path/to/workflows  # Analyze workflows in specific directory
+  comfywatchman --search civitai,huggingface  # Use specific search backends
+  comfywatchman inspect model.safetensors  # Inspect a single model file
+        """,
     )
 
     # Input options
     parser.add_argument(
-        'workflows',
-        nargs='*',
-        help='Specific workflow files to analyze'
+        "workflows",
+        nargs="*",
+        help="Specific workflow files to analyze",
     )
 
     parser.add_argument(
-        '--dir', '--workflow-dir',
-        action='append',
-        dest='workflow_dirs',
-        help='Directory to scan for workflow files (can be used multiple times)'
+        "--dir",
+        "--workflow-dir",
+        action="append",
+        dest="workflow_dirs",
+        help="Directory to scan for workflow files (can be used multiple times)",
     )
 
     # Search options
     parser.add_argument(
-        '--search', '--backends',
-        default='civitai',
-        help='Comma-separated list of search backends (default: civitai)'
+        "--search",
+        "--backends",
+        default="civitai",
+        help="Comma-separated list of search backends (default: civitai)",
     )
 
     # Mode options
     parser.add_argument(
-        '--v1',
-        action='store_true',
-        help='Use v1 compatibility mode (incremental processing)'
+        "--v1",
+        action="store_true",
+        help="Use v1 compatibility mode (incremental processing)",
     )
 
     parser.add_argument(
-        '--v2',
-        action='store_true',
-        help='Use v2 compatibility mode (batch processing, default)'
+        "--v2",
+        action="store_true",
+        help="Use v2 compatibility mode (batch processing, default)",
     )
 
     # Output options
     parser.add_argument(
-        '--output-dir',
+        "--output-dir",
         type=Path,
-        help=f'Output directory for results (default: {config.output_dir})'
+        help=f"Output directory for results (default: {config.output_dir})",
     )
 
     parser.add_argument(
-        '--no-script',
-        action='store_true',
-        help='Skip generating download script'
+        "--no-script",
+        action="store_true",
+        help="Skip generating download script",
     )
 
     parser.add_argument(
-        '--verify-urls',
-        action='store_true',
-        help='Enable URL verification during downloads'
+        "--verify-urls",
+        action="store_true",
+        help="Enable URL verification during downloads",
     )
 
     # Configuration
     parser.add_argument(
-        '--config',
+        "--config",
         type=Path,
-        help='Path to configuration file'
+        help="Path to configuration file",
     )
 
     parser.add_argument(
-        '--comfyui-root',
+        "--comfyui-root",
         type=Path,
-        help='Path to ComfyUI installation (required if not configured)'
+        help="Path to ComfyUI installation (required if not configured)",
     )
 
     # Logging
     parser.add_argument(
-        '--log-level',
-        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'],
-        default='INFO',
-        help='Set logging level (default: INFO)'
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default="INFO",
+        help="Set logging level (default: INFO)",
     )
 
     parser.add_argument(
-        '--quiet',
-        action='store_true',
-        help='Suppress non-error output'
+        "--quiet",
+        action="store_true",
+        help="Suppress non-error output",
     )
 
     parser.add_argument(
-        '--version',
-        action='version',
-        version=f'%(prog)s 2.0.0'
+        "--version",
+        action="version",
+        version="%(prog)s 2.0.0",
     )
 
+    return parser
+
+
+def create_inspect_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="comfywatchman inspect",
+        description="Inspect model metadata without loading tensors.",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="+",
+        help="Paths to files or directories to inspect",
+    )
+    parser.add_argument(
+        "--recursive",
+        action="store_true",
+        help="Recursively inspect directories",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    parser.add_argument(
+        "--summary",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Toggle condensed text output (default: enabled)",
+    )
+    parser.add_argument(
+        "--hash",
+        action="store_true",
+        help="Compute SHA256 hashes (can be slow)",
+    )
+    parser.add_argument(
+        "--unsafe",
+        action="store_true",
+        help="Allow unsafe torch.load for pickle checkpoints",
+    )
+    parser.add_argument(
+        "--components",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Include per-component listings for Diffusers directories",
+    )
+    parser.add_argument(
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default="INFO",
+        help="Set logging level (default: INFO)",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress non-error output",
+    )
     return parser
 
 
@@ -125,13 +180,12 @@ def setup_logging(log_level: str, quiet: bool) -> None:
     import logging
 
     if quiet:
-        log_level = 'ERROR'
+        log_level = "ERROR"
 
-    # Configure root logger
     logging.basicConfig(
         level=getattr(logging, log_level),
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S'
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
     )
 
 
@@ -139,38 +193,67 @@ def update_config_from_args(args: argparse.Namespace) -> None:
     """Update global config from command line arguments."""
     global config
 
-    if args.config and args.config.exists():
-        # Load config from file if specified
+    if getattr(args, "config", None) and args.config.exists():
         config.load_from_file(args.config)
 
-    # Override with command line arguments
-    if args.output_dir:
+    if getattr(args, "output_dir", None):
         config.output_dir = args.output_dir
-    if args.comfyui_root:
+    if getattr(args, "comfyui_root", None):
         config.comfyui_root = args.comfyui_root
 
 
-def main() -> int:
-    """Main CLI entry point."""
-    parser = create_parser()
-    args = parser.parse_args()
+def _run_inspect_command(args: argparse.Namespace) -> int:
+    from .inspector import inspect_paths
 
-    # Setup logging
-    setup_logging(args.log_level, args.quiet)
+    include_components = getattr(args, "components", True)
+    results = inspect_paths(
+        args.paths,
+        recursive=args.recursive,
+        fmt=args.format,
+        summary=args.summary,
+        do_hash=args.hash,
+        unsafe=args.unsafe,
+        include_components=include_components,
+    )
+
+    if args.format == "json":
+        payload: object
+        if isinstance(results, list) and len(results) == 1:
+            payload = results[0]
+        else:
+            payload = results
+        print(
+            json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True),
+            flush=True,
+        )
+    else:
+        print(results, flush=True)
+    return 0
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """Main CLI entry point."""
+    raw_args = list(sys.argv[1:] if argv is None else argv)
+
+    if raw_args and raw_args[0] == "inspect":
+        inspect_parser = create_inspect_parser()
+        inspect_args = inspect_parser.parse_args(raw_args[1:])
+        setup_logging(inspect_args.log_level, inspect_args.quiet)
+        return _run_inspect_command(inspect_args)
+
+    parser = create_parser()
+    args = parser.parse_args(raw_args)
+
+    setup_logging(getattr(args, "log_level", "INFO"), getattr(args, "quiet", False))
 
     logger = get_logger("ComfyFixerCLI")
 
     try:
-        # Update configuration
         update_config_from_args(args)
 
-        # Parse search backends
-        search_backends = [b.strip() for b in args.search.split(',')] if args.search else ['civitai']
+        search_backends = [b.strip() for b in args.search.split(",")] if args.search else ["civitai"]
 
-        # Determine workflow directories
-        workflow_dirs = args.workflow_dirs
-        if not workflow_dirs:
-            workflow_dirs = [str(d) for d in config.workflow_dirs]
+        workflow_dirs = args.workflow_dirs or [str(d) for d in config.workflow_dirs]
 
         logger.info("=" * 70)
         logger.info("ComfyFixerSmart v2.0.0 - Starting Analysis")
@@ -179,23 +262,19 @@ def main() -> int:
         logger.info(f"Search backends: {search_backends}")
         logger.info(f"Output directory: {config.output_dir}")
 
-        # Determine which mode to run
         if args.v1:
-            # V1 compatibility mode
             logger.info("Running in V1 compatibility mode (incremental)")
             result = run_v1_compatibility_mode(
                 specific_workflows=args.workflows if args.workflows else None,
-                verify_urls=args.verify_urls
+                verify_urls=args.verify_urls,
             )
         elif args.v2 or (not args.v1 and not args.v2):
-            # V2 mode (default)
             logger.info("Running in V2 mode (batch processing)")
             result = run_v2_compatibility_mode(
                 specific_workflows=args.workflows if args.workflows else None,
-                retry_failed=False  # Could add --retry flag later
+                retry_failed=False,
             )
         else:
-            # Unified mode using ComfyFixerCore
             logger.info("Running unified analysis")
             from .core import ComfyFixerCore
 
@@ -205,10 +284,9 @@ def main() -> int:
                 workflow_dirs=workflow_dirs,
                 search_backends=search_backends,
                 generate_script=not args.no_script,
-                verify_urls=args.verify_urls
+                verify_urls=args.verify_urls,
             )
 
-        # Report results
         if result:
             logger.info("=" * 70)
             logger.info("Analysis Complete!")
@@ -236,13 +314,15 @@ def main() -> int:
     except KeyboardInterrupt:
         logger.info("\nOperation cancelled by user")
         return 130
-    except Exception as e:
-        logger.error(f"Unexpected error: {e}")
-        if args.log_level == 'DEBUG':
+    except Exception as exc:  # pragma: no cover - defensive logging path
+        logger.error(f"Unexpected error: {exc}")
+        if getattr(args, "log_level", "INFO") == "DEBUG":
             import traceback
+
             logger.debug(traceback.format_exc())
         return 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())
+

--- a/src/comfyfixersmart/inspector.py
+++ b/src/comfyfixersmart/inspector.py
@@ -1,0 +1,562 @@
+"""Model metadata inspector for ComfyWatchman.
+
+This module provides deterministic utilities for inspecting model files
+and Diffusers directories without loading large tensors.  It is designed
+to be safe by default and expose only lightweight metadata so that users
+can triage assets locally.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Literal, Optional, Tuple
+
+
+SUPPORTED_EXTENSIONS = {
+    ".safetensors": "safetensors",
+    ".ckpt": "ckpt",
+    ".pt": "pt",
+    ".pth": "pth",
+    ".onnx": "onnx",
+    ".bin": "bin",
+}
+
+PICKLE_FORMATS = {"ckpt", "pt", "pth", "bin"}
+
+
+@dataclass
+class InspectionContext:
+    """Context shared across inspection calls."""
+
+    do_hash: bool = False
+    unsafe: bool = False
+    include_components: bool = True
+
+
+def inspect_file(
+    path: str,
+    *,
+    do_hash: bool = False,
+    unsafe: bool = False,
+    include_components: bool = True,
+) -> Dict[str, object]:
+    """Inspect a single file or Diffusers directory.
+
+    Parameters
+    ----------
+    path:
+        Path to the file or directory to inspect.
+    do_hash:
+        When ``True`` compute a SHA256 hash of files.  Hashing is skipped
+        for directories.
+    unsafe:
+        Opt-in flag that allows reading pickle based checkpoints via
+        ``torch.load``.  Disabled by default to avoid code execution.
+    include_components:
+        Controls whether Diffusers directories include per-file component
+        summaries.
+    """
+
+    target = Path(path)
+    ctx = InspectionContext(do_hash=do_hash, unsafe=unsafe, include_components=include_components)
+
+    if not target.exists():
+        return _missing_path_report(target)
+
+    if target.is_dir():
+        if _looks_like_diffusers_dir(target):
+            return _inspect_diffusers_dir(target, ctx)
+        return _inspect_generic_directory(target)
+
+    return _inspect_model_file(target, ctx)
+
+
+def inspect_paths(
+    paths: List[str],
+    *,
+    recursive: bool = False,
+    fmt: Literal["text", "json"] = "text",
+    summary: bool = True,
+    do_hash: bool = False,
+    unsafe: bool = False,
+    include_components: bool = True,
+) -> str | List[Dict[str, object]]:
+    """Inspect a collection of paths and render the result.
+
+    Parameters mirror :func:`inspect_file` with additional formatting
+    controls for CLI use.  Results are deterministic: traversal is sorted
+    and processing happens on a single thread.
+    """
+
+    ctx = InspectionContext(do_hash=do_hash, unsafe=unsafe, include_components=include_components)
+    collected: List[Dict[str, object]] = []
+
+    for root in sorted(paths, key=lambda p: str(Path(p))):
+        root_path = Path(root)
+        if not root_path.exists():
+            collected.append(_missing_path_report(root_path))
+            continue
+
+        if root_path.is_dir() and not _looks_like_diffusers_dir(root_path):
+            collected.extend(
+                _inspect_directory_entries(root_path, ctx, recursive=recursive)
+            )
+        else:
+            collected.append(_inspect_entry(root_path, ctx))
+
+    if fmt == "json":
+        return collected
+
+    return _render_text(collected, summary=summary)
+
+
+def _inspect_entry(path: Path, ctx: InspectionContext) -> Dict[str, object]:
+    if path.is_dir():
+        if _looks_like_diffusers_dir(path):
+            return _inspect_diffusers_dir(path, ctx)
+        return _inspect_generic_directory(path)
+    return _inspect_model_file(path, ctx)
+
+
+def _inspect_directory_entries(
+    directory: Path,
+    ctx: InspectionContext,
+    *,
+    recursive: bool,
+) -> List[Dict[str, object]]:
+    entries: List[Dict[str, object]] = []
+
+    if recursive:
+        for root, dirnames, filenames in os.walk(directory):
+            dirnames.sort()
+            filenames.sort()
+
+            root_path = Path(root)
+            if root_path != directory and _looks_like_diffusers_dir(root_path):
+                entries.append(_inspect_diffusers_dir(root_path, ctx))
+                # Skip descending into Diffusers directories further.
+                dirnames[:] = []
+                continue
+
+            for filename in filenames:
+                entries.append(_inspect_model_file(root_path / filename, ctx))
+    else:
+        for entry in sorted(directory.iterdir(), key=lambda p: (p.is_file(), p.name)):
+            if entry.is_file() or _looks_like_diffusers_dir(entry):
+                entries.append(_inspect_entry(entry, ctx))
+
+    return entries
+
+
+def _inspect_model_file(path: Path, ctx: InspectionContext) -> Dict[str, object]:
+    size_bytes = path.stat().st_size
+    extension = path.suffix.lower()
+    file_format = SUPPORTED_EXTENSIONS.get(extension, "other")
+    warnings: List[str] = []
+    metadata: Dict[str, object] = {}
+
+    if file_format == "safetensors":
+        metadata, meta_warnings = _extract_safetensors_metadata(path)
+        warnings.extend(meta_warnings)
+    elif file_format == "onnx":
+        meta, meta_warnings = _extract_onnx_metadata(path)
+        metadata.update(meta)
+        warnings.extend(meta_warnings)
+    elif file_format in PICKLE_FORMATS:
+        meta, meta_warnings = _extract_pickle_metadata(path, ctx.unsafe)
+        metadata.update(meta)
+        warnings.extend(meta_warnings)
+
+    sha_val = _hash_file(path) if ctx.do_hash else None
+
+    type_hint, family = _guess_type_hint(path, file_format, metadata, size_bytes)
+    source_hints = _guess_source_hints(path)
+
+    return {
+        "filename": path.name,
+        "path": str(path.resolve()),
+        "size_bytes": size_bytes,
+        "format": file_format,
+        "type_hint": type_hint,
+        "metadata": metadata,
+        "sha256": sha_val,
+        "source_hints": source_hints or None,
+        "warnings": warnings,
+        "family": family,
+    }
+
+
+def _inspect_diffusers_dir(path: Path, ctx: InspectionContext) -> Dict[str, object]:
+    warnings: List[str] = []
+    metadata: Dict[str, object] = {}
+    pipeline_class: Optional[str] = None
+    model_index_path = path / "model_index.json"
+
+    if model_index_path.exists():
+        try:
+            model_data = json.loads(model_index_path.read_text(encoding="utf-8"))
+            pipeline_class = (
+                model_data.get("_class_name")
+                or model_data.get("model_type")
+                or model_data.get("pipeline_class")
+            )
+            metadata["pipeline_class"] = pipeline_class
+            if "_diffusers_version" in model_data:
+                metadata["diffusers_version"] = str(model_data["_diffusers_version"])
+        except Exception as exc:  # pragma: no cover - safety guard
+            warnings.append(f"Failed to parse model_index.json: {exc}")
+    else:
+        warnings.append("Missing model_index.json")
+
+    components = _list_diffusers_components(path)
+    metadata["components"] = [comp[0] for comp in components]
+    if ctx.include_components:
+        metadata["files"] = [
+            {"name": comp[0], "size_bytes": comp[1], "extension": comp[2]}
+            for comp in components
+        ]
+
+    total_size = sum(comp[1] for comp in components)
+    type_hint, family = _guess_type_hint(path, "diffusers", metadata, total_size)
+
+    return {
+        "filename": path.name,
+        "path": str(path.resolve()),
+        "size_bytes": total_size,
+        "format": "diffusers",
+        "type_hint": type_hint,
+        "metadata": metadata,
+        "sha256": None,
+        "source_hints": _guess_source_hints(path) or None,
+        "warnings": warnings,
+        "family": family,
+    }
+
+
+def _inspect_generic_directory(path: Path) -> Dict[str, object]:
+    warnings = [
+        "Directory inspected without recursion; pass --recursive to traverse contents",
+    ]
+    return {
+        "filename": path.name,
+        "path": str(path.resolve()),
+        "size_bytes": 0,
+        "format": "directory",
+        "type_hint": "unknown",
+        "metadata": {},
+        "sha256": None,
+        "source_hints": _guess_source_hints(path) or None,
+        "warnings": warnings,
+        "family": None,
+    }
+
+
+def _missing_path_report(path: Path) -> Dict[str, object]:
+    return {
+        "filename": path.name,
+        "path": str(path),
+        "size_bytes": 0,
+        "format": "other",
+        "type_hint": "unknown",
+        "metadata": {},
+        "sha256": None,
+        "source_hints": None,
+        "warnings": ["Path not found"],
+        "family": None,
+    }
+
+
+def _extract_safetensors_metadata(path: Path) -> Tuple[Dict[str, object], List[str]]:
+    from importlib import import_module
+
+    warnings: List[str] = []
+    try:
+        safetensors = import_module("safetensors")
+        safe_open = getattr(safetensors, "safe_open")
+    except Exception as exc:  # pragma: no cover - import failure guarded via tests
+        warnings.append(f"safetensors import failed: {exc}")
+        return {}, warnings
+
+    try:
+        with safe_open(path, framework="numpy") as handle:  # type: ignore[call-arg]
+            header = handle.metadata() or {}
+    except Exception as exc:
+        warnings.append(f"Failed to read safetensors metadata: {exc}")
+        return {}, warnings
+
+    metadata = {
+        key: str(header[key]) for key in sorted(header.keys())[:20]
+    }
+    return metadata, warnings
+
+
+def _extract_onnx_metadata(path: Path) -> Tuple[Dict[str, object], List[str]]:
+    import importlib
+
+    warnings: List[str] = []
+    try:
+        onnx = importlib.import_module("onnx")
+    except ImportError:
+        warnings.append("onnx not installed; metadata unavailable")
+        return {}, warnings
+
+    try:
+        model = onnx.load(path, load_external_data=False)
+    except Exception as exc:
+        warnings.append(f"Failed to read ONNX file: {exc}")
+        return {}, warnings
+
+    metadata: Dict[str, object] = {}
+    metadata["ir_version"] = getattr(model, "ir_version", None)
+    if hasattr(model, "opset_import") and model.opset_import:
+        metadata["opset"] = [
+            {"domain": imp.domain or "", "version": imp.version}
+            for imp in model.opset_import
+        ]
+    if hasattr(model, "producer_name") and model.producer_name:
+        metadata["producer"] = str(model.producer_name)
+    if hasattr(model, "producer_version") and model.producer_version:
+        metadata["producer_version"] = str(model.producer_version)
+
+    return metadata, warnings
+
+
+def _extract_pickle_metadata(path: Path, unsafe: bool) -> Tuple[Dict[str, object], List[str]]:
+    import importlib
+
+    metadata: Dict[str, object] = {}
+    warnings: List[str] = []
+
+    if not unsafe:
+        metadata["unsafe"] = "disabled"
+        warnings.append("Unsafe loading disabled; showing file metadata only")
+        return metadata, warnings
+
+    try:
+        torch = importlib.import_module("torch")
+    except ImportError:
+        warnings.append("torch not installed; cannot perform unsafe load")
+        return metadata, warnings
+
+    try:
+        try:
+            loaded = torch.load(path, map_location="cpu", weights_only=True)
+        except TypeError:
+            loaded = torch.load(path, map_location="cpu")
+    except Exception as exc:  # pragma: no cover - runtime safety guard
+        warnings.append(f"torch.load failed: {exc}")
+        return metadata, warnings
+
+    metadata["unsafe_top_level"] = _summarize_top_level(loaded)
+    return metadata, warnings
+
+
+def _summarize_top_level(obj: object) -> Dict[str, object]:
+    summary: Dict[str, object] = {"type": type(obj).__name__}
+    if isinstance(obj, dict):
+        keys = list(obj.keys())
+        summary["key_count"] = len(keys)
+        summary["sample_keys"] = [str(key) for key in keys[:5]]
+    elif hasattr(obj, "state_dict"):
+        try:
+            state = obj.state_dict()
+            if isinstance(state, dict):
+                keys = list(state.keys())
+                summary["state_keys"] = [str(key) for key in keys[:5]]
+                summary["state_key_count"] = len(keys)
+        except Exception:  # pragma: no cover - defensive guard
+            pass
+    return summary
+
+
+def _hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _guess_type_hint(
+    path: Path,
+    file_format: str,
+    metadata: Dict[str, object],
+    size_bytes: int,
+) -> Tuple[str, Optional[str]]:
+    lowered_parts = [part.lower() for part in path.parts]
+    filename = path.name.lower()
+    family: Optional[str] = None
+
+    dir_type_map = {
+        "checkpoints": "checkpoint",
+        "models": "checkpoint",
+        "loras": "lora",
+        "lycoris": "lycoris",
+        "locon": "locon",
+        "embeddings": "embedding",
+        "hypernetworks": "hypernetwork",
+        "controlnet": "controlnet",
+        "clip": "clip",
+        "clip_vision": "clip_vision",
+        "vae": "vae",
+        "vae_approx": "vae_approx",
+        "upscale_models": "upscale",
+        "sam": "sam",
+        "t2i_adapter": "t2i_adapter",
+        "ipadapter": "ip_adapter",
+        "motion_lora": "motion",
+        "animatediff_models": "motion",
+        "segmentation": "segmentation",
+        "yolo": "yolo",
+        "flux": "flux",
+    }
+
+    for part in lowered_parts:
+        if part in dir_type_map:
+            hint = dir_type_map[part]
+            if hint == "flux":
+                family = "flux"
+                hint = "checkpoint"
+            return hint, family
+
+    text_blob = " ".join(str(value).lower() for value in metadata.values())
+    meta_keywords = [
+        ("flux", "flux"),
+        ("lora", "lora"),
+        ("lycoris", "lycoris"),
+        ("locon", "locon"),
+        ("controlnet", "controlnet"),
+        ("vae", "vae"),
+        ("ipadapter", "ip_adapter"),
+        ("embedding", "embedding"),
+        ("clip vision", "clip_vision"),
+        ("t2i", "t2i_adapter"),
+        ("sam", "sam"),
+        ("hypernetwork", "hypernetwork"),
+        ("upscale", "upscale"),
+    ]
+
+    for keyword, hint in meta_keywords:
+        if keyword in text_blob:
+            if hint == "flux":
+                family = "flux"
+                return "checkpoint", family
+            if hint == "vae":
+                return "vae", family
+            return hint, family
+
+    filename_map = [
+        (r"^ti_", "embedding"),
+        (r"embedding", "embedding"),
+        (r"lycoris", "lycoris"),
+        (r"locon", "locon"),
+        (r"ip.?adapter", "ip_adapter"),
+        (r"t2i[_-]?adapter", "t2i_adapter"),
+        (r"hypernetwork", "hypernetwork"),
+        (r"controlnet", "controlnet"),
+        (r"clip_vision", "clip_vision"),
+        (r"^sam_", "sam"),
+        (r"realesrgan|esrgan", "upscale"),
+        (r"gfpgan|codeformer", "face_restore"),
+        (r"yolo", "yolo"),
+        (r"flux", "checkpoint"),
+        (r"t5", "t5"),
+        (r"animatediff|motion", "motion"),
+        (r"vae", "vae"),
+    ]
+
+    for pattern, hint in filename_map:
+        if re.search(pattern, filename):
+            if pattern == r"flux":
+                family = "flux"
+            if hint == "checkpoint" and family == "flux":
+                return hint, family
+            return hint, family
+
+    if file_format in {"safetensors", "ckpt", "pt", "pth"}:
+        if size_bytes >= 2 * 1024 * 1024 * 1024:
+            return "checkpoint", family
+        if size_bytes <= 200 * 1024 * 1024:
+            return "lora", family
+        if size_bytes <= 600 * 1024 * 1024 and "vae" in filename:
+            return "vae", family
+
+    if file_format == "onnx":
+        return "clip" if "clip" in filename else "unknown", family
+
+    return "unknown", family
+
+
+def _guess_source_hints(path: Path) -> List[str]:
+    hints: List[str] = []
+    path_str = str(path).lower()
+    if "civitai" in path_str:
+        hints.append("civitai")
+    if "huggingface" in path_str or "hf_" in path.name.lower():
+        hints.append("huggingface")
+    if "github" in path_str:
+        hints.append("github")
+    return hints
+
+
+def _looks_like_diffusers_dir(path: Path) -> bool:
+    if not path.is_dir():
+        return False
+    return (path / "model_index.json").exists()
+
+
+def _list_diffusers_components(path: Path) -> List[Tuple[str, int, str]]:
+    components: List[Tuple[str, int, str]] = []
+    for root, _, files in os.walk(path):
+        rel_root = Path(root)
+        files.sort()
+        for file_name in files:
+            file_path = rel_root / file_name
+            extension = file_path.suffix.lower()
+            if extension not in SUPPORTED_EXTENSIONS and extension not in {".json"}:
+                continue
+            relative = file_path.relative_to(path)
+            size = file_path.stat().st_size
+            components.append((str(relative), size, extension.lstrip(".")))
+    components.sort(key=lambda item: item[0])
+    return components
+
+
+def _render_text(entries: Iterable[Dict[str, object]], *, summary: bool) -> str:
+    lines: List[str] = []
+    for entry in entries:
+        first_line = (
+            f"{entry['filename']} | format={entry['format']} | type={entry['type_hint']} | "
+            f"size={entry['size_bytes']}"
+        )
+        lines.append(first_line)
+
+        if not summary:
+            metadata = entry.get("metadata") or {}
+            if metadata:
+                items = list(metadata.items())
+                formatted_items = []
+                for key, value in items[:5]:
+                    formatted_items.append(f"{key}={value}")
+                lines.append("  metadata: " + "; ".join(formatted_items))
+
+            if entry.get("sha256"):
+                lines.append(f"  sha256: {entry['sha256']}")
+
+        warnings = entry.get("warnings") or []
+        if warnings:
+            lines.append("  warnings: " + " | ".join(str(w) for w in warnings))
+
+    return "\n".join(lines)
+
+
+__all__ = [
+    "inspect_file",
+    "inspect_paths",
+]
+

--- a/tests/unit/test_inspector.py
+++ b/tests/unit/test_inspector.py
@@ -1,0 +1,211 @@
+import importlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from comfyfixersmart.inspector import inspect_file, inspect_paths
+
+
+def _create_dummy_file(path: Path, content: bytes = b"data") -> None:
+    path.write_bytes(content)
+
+
+def test_inspect_file_safetensors_metadata(tmp_path):
+    safetensors = pytest.importorskip("safetensors")
+    numpy = pytest.importorskip("numpy")
+
+    data = {"embedding": numpy.zeros((1,), dtype=numpy.float32)}
+    metadata = {"ss_network_module": "lora"}
+
+    output_file = tmp_path / "tiny_lora.safetensors"
+    safetensors.numpy.save_file(data, str(output_file), metadata=metadata)
+
+    info = inspect_file(str(output_file))
+
+    assert info["format"] == "safetensors"
+    assert info["metadata"]["ss_network_module"] == "lora"
+    assert info["type_hint"] == "lora"
+    assert info["warnings"] == []
+
+
+def test_inspect_file_flux_family(tmp_path):
+    safetensors = pytest.importorskip("safetensors")
+    numpy = pytest.importorskip("numpy")
+
+    data = {"weights": numpy.zeros((1,), dtype=numpy.float32)}
+    metadata = {"modelspec.architecture": "flux", "format": "checkpoint"}
+
+    output_file = tmp_path / "flux_model.safetensors"
+    safetensors.numpy.save_file(data, str(output_file), metadata=metadata)
+
+    info = inspect_file(str(output_file))
+
+    assert info["family"] == "flux"
+    assert info["type_hint"] == "checkpoint"
+
+
+def test_inspect_pickle_safe_mode(tmp_path):
+    file_path = tmp_path / "model.pth"
+    _create_dummy_file(file_path)
+
+    info = inspect_file(str(file_path))
+
+    assert info["format"] == "pth"
+    assert info["metadata"]["unsafe"] == "disabled"
+    assert any("Unsafe" in warning for warning in info["warnings"])
+
+
+def test_inspect_pickle_unsafe(tmp_path):
+    torch = pytest.importorskip("torch", reason="torch required for unsafe test")
+
+    file_path = tmp_path / "state_dict.ckpt"
+    tensor = torch.zeros(1)
+    torch.save({"layer.weight": tensor}, file_path)
+
+    info = inspect_file(str(file_path), unsafe=True)
+
+    metadata = info["metadata"]["unsafe_top_level"]
+    assert metadata["type"] in {"dict", "OrderedDict"}
+    assert metadata["key_count"] == 1
+    assert metadata["sample_keys"] == ["layer.weight"]
+
+
+def test_inspect_onnx_metadata(tmp_path):
+    onnx = pytest.importorskip("onnx")
+
+    from onnx import helper, TensorProto
+
+    node = helper.make_node("Relu", inputs=["X"], outputs=["Y"])
+    graph = helper.make_graph(
+        [node],
+        "TestGraph",
+        [helper.make_tensor_value_info("X", TensorProto.FLOAT, [1])],
+        [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1])],
+    )
+    model = helper.make_model(graph, producer_name="pytest")
+
+    file_path = tmp_path / "model.onnx"
+    onnx.save(model, file_path)
+
+    info = inspect_file(str(file_path))
+
+    assert info["format"] == "onnx"
+    assert "ir_version" in info["metadata"]
+    assert info["warnings"] == []
+
+
+def test_inspect_onnx_missing_dependency(tmp_path, monkeypatch):
+    file_path = tmp_path / "missing.onnx"
+    _create_dummy_file(file_path)
+
+    original_import_module = importlib.import_module
+
+    def fake_import(name):
+        if name == "onnx":
+            raise ImportError("onnx unavailable")
+        return original_import_module(name)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+
+    info = inspect_file(str(file_path))
+
+    assert info["format"] == "onnx"
+    assert "onnx not installed" in info["warnings"][0]
+
+
+def test_inspect_paths_directory_recursive(tmp_path):
+    (tmp_path / "sub").mkdir()
+    file_a = tmp_path / "sub" / "b_model.safetensors"
+    file_b = tmp_path / "sub" / "a_model.bin"
+    _create_dummy_file(file_a)
+    _create_dummy_file(file_b)
+
+    results = inspect_paths([str(tmp_path)], recursive=True, fmt="json")
+
+    filenames = [entry["filename"] for entry in results]
+    assert filenames == sorted(filenames)
+
+
+def test_diffusers_directory_summary(tmp_path):
+    repo = tmp_path / "diff_repo"
+    (repo / "unet").mkdir(parents=True)
+    (repo / "text_encoder").mkdir()
+
+    model_index = {
+        "_class_name": "StableDiffusionPipeline",
+        "_diffusers_version": "0.20.0",
+    }
+    (repo / "model_index.json").write_text(json.dumps(model_index), encoding="utf-8")
+    (repo / "unet" / "diffusion_pytorch_model.bin").write_bytes(b"123")
+    (repo / "text_encoder" / "model.safetensors").write_bytes(b"456")
+
+    info = inspect_file(str(repo))
+    assert info["format"] == "diffusers"
+    assert "pipeline_class" in info["metadata"]
+    component_names = {item["name"] for item in info["metadata"]["files"]}
+    assert {
+        "model_index.json",
+        "text_encoder/model.safetensors",
+        "unet/diffusion_pytorch_model.bin",
+    }.issubset(component_names)
+
+    results = inspect_paths([str(repo)], fmt="json", include_components=False)
+    assert isinstance(results, list)
+    assert "files" not in results[0]["metadata"]
+
+
+def test_cli_inspect_text_single_file(tmp_path):
+    file_path = tmp_path / "model.bin"
+    _create_dummy_file(file_path)
+
+    env = os.environ.copy()
+    root = Path(__file__).resolve().parents[2] / "src"
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = f"{root}{os.pathsep}{existing}" if existing else str(root)
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "comfyfixersmart.cli", "inspect", str(file_path)],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+
+    assert "model.bin" in proc.stdout
+
+
+def test_cli_inspect_json_single_file(tmp_path):
+    file_path = tmp_path / "model.safetensors"
+    _create_dummy_file(file_path)
+
+    env = os.environ.copy()
+    root = Path(__file__).resolve().parents[2] / "src"
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = f"{root}{os.pathsep}{existing}" if existing else str(root)
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "comfyfixersmart.cli",
+            "inspect",
+            str(file_path),
+            "--format",
+            "json",
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+
+    payload = json.loads(proc.stdout.strip())
+    assert payload["filename"] == "model.safetensors"
+    assert payload["format"] == "safetensors"
+


### PR DESCRIPTION
## Summary
- add a safe, deterministic metadata inspector capable of handling ComfyUI model assets and Diffusers folders
- extend the comfywatchman CLI with an `inspect` command that surfaces the inspector features
- document usage, wire up optional dependencies, and cover the new behaviour with targeted unit tests

## Testing
- PYTHONPATH=src pytest tests/unit/test_inspector.py

------
https://chatgpt.com/codex/tasks/task_b_68f5a69a7190832bad0952f03602dffe