### PR TITLE
test: add initial test suite for scanner and config modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ Thumbs.db
 state/
 output/
 config/.compatibility_state.json
+_open_prs.json
+_open_issues.json
+_repo_metadata.json
 
 # Temporary files
 *.tmp

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,129 @@
+"""
+Shared pytest fixtures for ComfyWatchman test suite.
+
+Note: ComfyUI workflows use a node-list format where each node has
+'id', 'type', 'widgets_values', and 'inputs' fields.
+"""
+import json
+
+import pytest
+
+
+@pytest.fixture
+def simple_workflow():
+    """Minimal valid ComfyUI workflow with one checkpoint loader node."""
+    return {
+        "nodes": [
+            {
+                "id": 1,
+                "type": "CheckpointLoaderSimple",
+                "widgets_values": ["dreamshaper_8.safetensors"],
+                "inputs": {},
+            },
+            {
+                "id": 2,
+                "type": "KSampler",
+                "widgets_values": [42, "euler", "normal", 7.0, 20, "fixed"],
+                "inputs": {"model": [1, 0], "positive": [3, 0]},
+            },
+        ]
+    }
+
+
+@pytest.fixture
+def complex_workflow():
+    """Workflow with multiple model types: checkpoint, LoRA, and ControlNet."""
+    return {
+        "nodes": [
+            {
+                "id": 1,
+                "type": "CheckpointLoaderSimple",
+                "widgets_values": ["realistic_vision_v6.safetensors"],
+                "inputs": {},
+            },
+            {
+                "id": 2,
+                "type": "LoraLoader",
+                "widgets_values": ["detail_tweaker.safetensors", 0.8, 0.8],
+                "inputs": {"model": [1, 0]},
+            },
+            {
+                "id": 3,
+                "type": "ControlNetLoader",
+                "widgets_values": ["control_v11p_sd15_canny.pth"],
+                "inputs": {},
+            },
+            {
+                "id": 4,
+                "type": "KSampler",
+                "widgets_values": [42, "euler", "normal", 7.0, 20, "fixed"],
+                "inputs": {},
+            },
+        ]
+    }
+
+
+@pytest.fixture
+def empty_workflow():
+    """Workflow with no model loader nodes — only text encoding and sampling."""
+    return {
+        "nodes": [
+            {
+                "id": 1,
+                "type": "CLIPTextEncode",
+                "widgets_values": ["a cat sitting on a bench"],
+                "inputs": {"clip": [2, 0]},
+            },
+            {
+                "id": 2,
+                "type": "KSampler",
+                "widgets_values": [42, "euler", "normal", 7.0, 20, "fixed"],
+                "inputs": {},
+            },
+        ]
+    }
+
+
+@pytest.fixture
+def embedding_workflow():
+    """Workflow that references embeddings via 'embedding:name' tokens in prompt text."""
+    return {
+        "nodes": [
+            {
+                "id": 1,
+                "type": "CLIPTextEncode",
+                "widgets_values": ["a photo of embedding:BadDream style"],
+                "inputs": {},
+            },
+            {
+                "id": 2,
+                "type": "CLIPTextEncode",
+                "widgets_values": ["embedding:EasyNegative ugly"],
+                "inputs": {},
+            },
+        ]
+    }
+
+
+@pytest.fixture
+def workflow_file(tmp_path, simple_workflow):
+    """Write the simple workflow to a temporary JSON file on disk."""
+    f = tmp_path / "test_workflow.json"
+    f.write_text(json.dumps(simple_workflow), encoding="utf-8")
+    return f
+
+
+@pytest.fixture
+def complex_workflow_file(tmp_path, complex_workflow):
+    """Write the complex workflow to a temporary JSON file on disk."""
+    f = tmp_path / "complex_workflow.json"
+    f.write_text(json.dumps(complex_workflow), encoding="utf-8")
+    return f
+
+
+@pytest.fixture
+def empty_workflow_file(tmp_path, empty_workflow):
+    """Write the empty workflow to a temporary JSON file on disk."""
+    f = tmp_path / "empty_workflow.json"
+    f.write_text(json.dumps(empty_workflow), encoding="utf-8")
+    return f

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,62 @@ Shared pytest fixtures for ComfyWatchman test suite.
 Note: ComfyUI workflows use a node-list format where each node has
 'id', 'type', 'widgets_values', and 'inputs' fields.
 """
-import json
+import logging
+import os
+import sys
+import tempfile
+from pathlib import Path
 
 import pytest
+
+_ORIG_CWD = None
+_SESSION_TMPDIR = None
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SRC_ROOT = _REPO_ROOT / "src"
+
+
+def pytest_sessionstart(session):
+    """Isolate import-time Config directory creation from the checkout."""
+    global _ORIG_CWD, _SESSION_TMPDIR
+
+    _ORIG_CWD = os.getcwd()
+    for path in (_REPO_ROOT, _SRC_ROOT):
+        path_str = str(path)
+        if path_str not in sys.path:
+            sys.path.insert(0, path_str)
+
+    _SESSION_TMPDIR = tempfile.TemporaryDirectory()
+    os.chdir(_SESSION_TMPDIR.name)
+
+    for env_var in ("OUTPUT_DIR", "LOG_DIR", "TEMP_DIR"):
+        os.environ.setdefault(env_var, _SESSION_TMPDIR.name)
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Restore the original working directory after the test session."""
+    global _ORIG_CWD, _SESSION_TMPDIR
+
+    for logger_obj in logging.Logger.manager.loggerDict.values():
+        if not isinstance(logger_obj, logging.Logger):
+            continue
+        for handler in list(logger_obj.handlers):
+            handler.close()
+            logger_obj.removeHandler(handler)
+
+    if _ORIG_CWD is not None:
+        os.chdir(_ORIG_CWD)
+        _ORIG_CWD = None
+
+    if _SESSION_TMPDIR is not None:
+        _SESSION_TMPDIR.cleanup()
+        _SESSION_TMPDIR = None
+
+
+def write_workflow_json(path, workflow):
+    import json
+
+    path.write_text(json.dumps(workflow), encoding="utf-8")
+    return path
 
 
 @pytest.fixture
@@ -109,21 +162,18 @@ def embedding_workflow():
 def workflow_file(tmp_path, simple_workflow):
     """Write the simple workflow to a temporary JSON file on disk."""
     f = tmp_path / "test_workflow.json"
-    f.write_text(json.dumps(simple_workflow), encoding="utf-8")
-    return f
+    return write_workflow_json(f, simple_workflow)
 
 
 @pytest.fixture
 def complex_workflow_file(tmp_path, complex_workflow):
     """Write the complex workflow to a temporary JSON file on disk."""
     f = tmp_path / "complex_workflow.json"
-    f.write_text(json.dumps(complex_workflow), encoding="utf-8")
-    return f
+    return write_workflow_json(f, complex_workflow)
 
 
 @pytest.fixture
 def empty_workflow_file(tmp_path, empty_workflow):
     """Write the empty workflow to a temporary JSON file on disk."""
     f = tmp_path / "empty_workflow.json"
-    f.write_text(json.dumps(empty_workflow), encoding="utf-8")
-    return f
+    return write_workflow_json(f, empty_workflow)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,122 @@
+"""
+Unit tests for config.py (Config, CopilotConfig, SearchConfig, DownloadConfig dataclasses).
+"""
+
+from comfywatchman.config import (
+    Config,
+    CopilotConfig,
+    DownloadConfig,
+    SearchConfig,
+    StateConfig,
+)
+
+
+class TestCopilotConfig:
+    def test_defaults(self):
+        """CopilotConfig should default to all-disabled."""
+        cfg = CopilotConfig()
+        assert cfg.enable_validation is False
+        assert cfg.enable_auto_repair is False
+        assert cfg.enable_modelscope is False
+
+    def test_can_enable_validation(self):
+        """enable_validation can be set to True."""
+        cfg = CopilotConfig(enable_validation=True)
+        assert cfg.enable_validation is True
+
+    def test_can_enable_all(self):
+        """All flags can be toggled independently."""
+        cfg = CopilotConfig(enable_validation=True, enable_auto_repair=True, enable_modelscope=True)
+        assert cfg.enable_validation is True
+        assert cfg.enable_auto_repair is True
+        assert cfg.enable_modelscope is True
+
+
+class TestSearchConfig:
+    def test_cache_enabled_by_default(self):
+        """Search cache should be enabled by default."""
+        cfg = SearchConfig()
+        assert cfg.enable_cache is True
+
+    def test_cache_ttl_default(self):
+        """Default cache TTL should be 86400 seconds (1 day)."""
+        cfg = SearchConfig()
+        assert cfg.cache_ttl == 86_400
+
+    def test_min_confidence_threshold_default(self):
+        """Default minimum confidence threshold should be 50."""
+        cfg = SearchConfig()
+        assert cfg.min_confidence_threshold == 50
+
+    def test_qwen_enabled_by_default(self):
+        """Qwen backend should be enabled by default."""
+        cfg = SearchConfig()
+        assert cfg.enable_qwen is True
+
+    def test_cache_can_be_disabled(self):
+        """enable_cache can be set to False."""
+        cfg = SearchConfig(enable_cache=False)
+        assert cfg.enable_cache is False
+
+
+class TestDownloadConfig:
+    def test_default_mode_is_python(self):
+        """Default download mode should be 'python'."""
+        cfg = DownloadConfig()
+        assert cfg.mode == "python"
+
+    def test_verify_hashes_enabled_by_default(self):
+        """Hash verification should be enabled by default."""
+        cfg = DownloadConfig()
+        assert cfg.verify_hashes is True
+
+    def test_default_max_retries(self):
+        """Default max retries should be 3."""
+        cfg = DownloadConfig()
+        assert cfg.max_retries == 3
+
+    def test_can_override_mode(self):
+        """Download mode can be changed to 'script'."""
+        cfg = DownloadConfig(mode="script")
+        assert cfg.mode == "script"
+
+
+class TestStateConfig:
+    def test_default_backend_is_json(self):
+        """Default state backend should be 'json'."""
+        cfg = StateConfig()
+        assert cfg.backend == "json"
+
+    def test_json_path_default(self):
+        """Default JSON state path should be 'state/'."""
+        cfg = StateConfig()
+        assert cfg.json_path == "state/"
+
+
+class TestConfigModelTypeMapping:
+    def test_checkpoint_loader_maps_to_checkpoints(self):
+        """CheckpointLoaderSimple must map to 'checkpoints' directory."""
+        # Access the factory default without triggering __post_init__
+        mapping = Config.__dataclass_fields__["model_type_mapping"].default_factory()
+        assert mapping["CheckpointLoaderSimple"] == "checkpoints"
+
+    def test_lora_loader_maps_to_loras(self):
+        """LoraLoader must map to 'loras' directory."""
+        mapping = Config.__dataclass_fields__["model_type_mapping"].default_factory()
+        assert mapping["LoraLoader"] == "loras"
+
+    def test_vae_loader_maps_to_vae(self):
+        """VAELoader must map to 'vae' directory."""
+        mapping = Config.__dataclass_fields__["model_type_mapping"].default_factory()
+        assert mapping["VAELoader"] == "vae"
+
+    def test_controlnet_loader_maps_to_controlnet(self):
+        """ControlNetLoader must map to 'controlnet' directory."""
+        mapping = Config.__dataclass_fields__["model_type_mapping"].default_factory()
+        assert mapping["ControlNetLoader"] == "controlnet"
+
+    def test_model_extensions_defaults(self):
+        """Default model extensions should include .safetensors and .ckpt."""
+        extensions = Config.__dataclass_fields__["model_extensions"].default_factory()
+        assert ".safetensors" in extensions
+        assert ".ckpt" in extensions

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,13 +2,35 @@
 Unit tests for config.py (Config, CopilotConfig, SearchConfig, DownloadConfig dataclasses).
 """
 
-from comfywatchman.config import (
-    Config,
-    CopilotConfig,
-    DownloadConfig,
-    SearchConfig,
-    StateConfig,
-)
+
+def Config(*args, **kwargs):
+    from comfywatchman.config import Config as _Config
+
+    return _Config(*args, **kwargs)
+
+
+def CopilotConfig(*args, **kwargs):
+    from comfywatchman.config import CopilotConfig as _CopilotConfig
+
+    return _CopilotConfig(*args, **kwargs)
+
+
+def DownloadConfig(*args, **kwargs):
+    from comfywatchman.config import DownloadConfig as _DownloadConfig
+
+    return _DownloadConfig(*args, **kwargs)
+
+
+def SearchConfig(*args, **kwargs):
+    from comfywatchman.config import SearchConfig as _SearchConfig
+
+    return _SearchConfig(*args, **kwargs)
+
+
+def StateConfig(*args, **kwargs):
+    from comfywatchman.config import StateConfig as _StateConfig
+
+    return _StateConfig(*args, **kwargs)
 
 
 class TestCopilotConfig:
@@ -96,27 +118,26 @@ class TestStateConfig:
 class TestConfigModelTypeMapping:
     def test_checkpoint_loader_maps_to_checkpoints(self):
         """CheckpointLoaderSimple must map to 'checkpoints' directory."""
-        # Access the factory default without triggering __post_init__
-        mapping = Config.__dataclass_fields__["model_type_mapping"].default_factory()
-        assert mapping["CheckpointLoaderSimple"] == "checkpoints"
+        cfg = Config()
+        assert cfg.model_type_mapping["CheckpointLoaderSimple"] == "checkpoints"
 
     def test_lora_loader_maps_to_loras(self):
         """LoraLoader must map to 'loras' directory."""
-        mapping = Config.__dataclass_fields__["model_type_mapping"].default_factory()
-        assert mapping["LoraLoader"] == "loras"
+        cfg = Config()
+        assert cfg.model_type_mapping["LoraLoader"] == "loras"
 
     def test_vae_loader_maps_to_vae(self):
         """VAELoader must map to 'vae' directory."""
-        mapping = Config.__dataclass_fields__["model_type_mapping"].default_factory()
-        assert mapping["VAELoader"] == "vae"
+        cfg = Config()
+        assert cfg.model_type_mapping["VAELoader"] == "vae"
 
     def test_controlnet_loader_maps_to_controlnet(self):
         """ControlNetLoader must map to 'controlnet' directory."""
-        mapping = Config.__dataclass_fields__["model_type_mapping"].default_factory()
-        assert mapping["ControlNetLoader"] == "controlnet"
+        cfg = Config()
+        assert cfg.model_type_mapping["ControlNetLoader"] == "controlnet"
 
     def test_model_extensions_defaults(self):
         """Default model extensions should include .safetensors and .ckpt."""
-        extensions = Config.__dataclass_fields__["model_extensions"].default_factory()
-        assert ".safetensors" in extensions
-        assert ".ckpt" in extensions
+        cfg = Config()
+        assert ".safetensors" in cfg.model_extensions
+        assert ".ckpt" in cfg.model_extensions

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -9,9 +9,10 @@ strings that end in recognised model extensions (.safetensors, .ckpt, .pt,
 .bin, .pth).  Embedding references are extracted from text strings matching
 the "embedding:<name>" pattern.
 """
-import json
+def WorkflowScanner(*args, **kwargs):
+    from comfywatchman.scanner import WorkflowScanner as _WorkflowScanner
 
-from comfywatchman.scanner import WorkflowScanner
+    return _WorkflowScanner(*args, **kwargs)
 
 
 # ---------------------------------------------------------------------------
@@ -19,6 +20,8 @@ from comfywatchman.scanner import WorkflowScanner
 # ---------------------------------------------------------------------------
 
 def _write_workflow(path, data):
+    import json
+
     path.write_text(json.dumps(data), encoding="utf-8")
     return str(path)
 
@@ -202,9 +205,7 @@ class TestExtractModels:
         scanner = WorkflowScanner()
         models = scanner.extract_models_from_workflow(path)
         embedding_types = [m for m in models if m.type == "embeddings"]
-        assert len(embedding_types) >= 1
-        filenames = [m.filename for m in embedding_types]
-        assert any("BadDream" in fn for fn in filenames)
+        assert [m.filename for m in embedding_types] == ["BadDream.pt", "EasyNegative.pt"]
 
     def test_duplicate_embedding_not_extracted_twice(self, tmp_path):
         """The same embedding referenced in two nodes is only extracted once."""

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,0 +1,289 @@
+"""
+Unit tests for WorkflowScanner (scanner.py).
+
+The scanner uses the ComfyUI native node-list format:
+    {"nodes": [{"id": ..., "type": ..., "widgets_values": [...], "inputs": {...}}]}
+
+Model filenames are discovered by inspecting each node's widgets_values for
+strings that end in recognised model extensions (.safetensors, .ckpt, .pt,
+.bin, .pth).  Embedding references are extracted from text strings matching
+the "embedding:<name>" pattern.
+"""
+import json
+
+from comfywatchman.scanner import WorkflowScanner
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_workflow(path, data):
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# Test: scan_workflows / _scan_specific_paths
+# ---------------------------------------------------------------------------
+
+class TestScanWorkflows:
+    def test_scan_specific_valid_path(self, tmp_path, simple_workflow):
+        """scan_workflows returns the path when it points to an existing JSON file."""
+        f = tmp_path / "wf.json"
+        _write_workflow(f, simple_workflow)
+        scanner = WorkflowScanner()
+        result = scanner.scan_workflows(specific_paths=[str(f)])
+        assert str(f) in result
+
+    def test_scan_specific_nonexistent_file_is_skipped(self, tmp_path):
+        """Non-existent specific path is silently skipped."""
+        scanner = WorkflowScanner()
+        result = scanner.scan_workflows(specific_paths=[str(tmp_path / "ghost.json")])
+        assert result == []
+
+    def test_scan_specific_non_json_file_is_skipped(self, tmp_path):
+        """A file that doesn't end in .json is excluded even if it exists."""
+        f = tmp_path / "not_a_workflow.txt"
+        f.write_text("{}", encoding="utf-8")
+        scanner = WorkflowScanner()
+        result = scanner.scan_workflows(specific_paths=[str(f)])
+        assert result == []
+
+    def test_scan_directory_returns_json_files(self, tmp_path, simple_workflow):
+        """scan_workflows finds JSON files when given a directory."""
+        _write_workflow(tmp_path / "a.json", simple_workflow)
+        _write_workflow(tmp_path / "b.json", simple_workflow)
+        scanner = WorkflowScanner()
+        result = scanner.scan_workflows(workflow_dirs=[str(tmp_path)])
+        assert len(result) == 2
+
+    def test_scan_nonexistent_directory_returns_empty(self, tmp_path):
+        """scan_workflows returns empty list for a directory that does not exist."""
+        scanner = WorkflowScanner()
+        result = scanner.scan_workflows(workflow_dirs=[str(tmp_path / "does_not_exist")])
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Test: extract_models_from_workflow
+# ---------------------------------------------------------------------------
+
+class TestExtractModels:
+    def test_checkpoint_model_extracted(self, tmp_path, simple_workflow):
+        """A CheckpointLoaderSimple node yields one ModelReference."""
+        path = _write_workflow(tmp_path / "wf.json", simple_workflow)
+        scanner = WorkflowScanner()
+        models = scanner.extract_models_from_workflow(path)
+        assert len(models) == 1
+        assert models[0].filename == "dreamshaper_8.safetensors"
+
+    def test_checkpoint_type_is_checkpoints(self, tmp_path, simple_workflow):
+        """Model type for CheckpointLoaderSimple is 'checkpoints'."""
+        path = _write_workflow(tmp_path / "wf.json", simple_workflow)
+        scanner = WorkflowScanner()
+        models = scanner.extract_models_from_workflow(path)
+        assert models[0].type == "checkpoints"
+
+    def test_checkpoint_node_type_preserved(self, tmp_path, simple_workflow):
+        """node_type on the ModelReference matches the source node's type field."""
+        path = _write_workflow(tmp_path / "wf.json", simple_workflow)
+        scanner = WorkflowScanner()
+        models = scanner.extract_models_from_workflow(path)
+        assert models[0].node_type == "CheckpointLoaderSimple"
+
+    def test_lora_model_extracted(self, tmp_path, complex_workflow):
+        """A LoraLoader node yields a ModelReference of type 'loras'."""
+        path = _write_workflow(tmp_path / "wf.json", complex_workflow)
+        scanner = WorkflowScanner()
+        models = scanner.extract_models_from_workflow(path)
+        loras = [m for m in models if m.node_type == "LoraLoader"]
+        assert len(loras) == 1
+        assert loras[0].filename == "detail_tweaker.safetensors"
+        assert loras[0].type == "loras"
+
+    def test_controlnet_model_extracted(self, tmp_path, complex_workflow):
+        """A ControlNetLoader node yields a ModelReference of type 'controlnet'."""
+        path = _write_workflow(tmp_path / "wf.json", complex_workflow)
+        scanner = WorkflowScanner()
+        models = scanner.extract_models_from_workflow(path)
+        controlnets = [m for m in models if m.node_type == "ControlNetLoader"]
+        assert len(controlnets) == 1
+        assert controlnets[0].filename == "control_v11p_sd15_canny.pth"
+        assert controlnets[0].type == "controlnet"
+
+    def test_complex_workflow_yields_three_models(self, tmp_path, complex_workflow):
+        """The complex workflow (checkpoint + lora + controlnet) yields exactly 3 models."""
+        path = _write_workflow(tmp_path / "wf.json", complex_workflow)
+        scanner = WorkflowScanner()
+        models = scanner.extract_models_from_workflow(path)
+        assert len(models) == 3
+
+    def test_empty_workflow_yields_no_models(self, tmp_path, empty_workflow):
+        """A workflow with no model-loader nodes yields an empty list."""
+        path = _write_workflow(tmp_path / "wf.json", empty_workflow)
+        scanner = WorkflowScanner()
+        models = scanner.extract_models_from_workflow(path)
+        assert models == []
+
+    def test_path_prefixes_are_stripped_from_filename(self, tmp_path):
+        """Model references that include directory prefixes are stripped to basename only."""
+        workflow = {
+            "nodes": [
+                {
+                    "id": 1,
+                    "type": "CheckpointLoaderSimple",
+                    "widgets_values": ["subdir/v1-5-pruned.safetensors"],
+                    "inputs": {},
+                }
+            ]
+        }
+        path = _write_workflow(tmp_path / "wf.json", workflow)
+        scanner = WorkflowScanner()
+        models = scanner.extract_models_from_workflow(path)
+        assert models[0].filename == "v1-5-pruned.safetensors"
+
+    def test_invalid_json_returns_empty_list(self, tmp_path):
+        """Malformed JSON causes extract_models_from_workflow to return an empty list."""
+        bad_file = tmp_path / "bad.json"
+        bad_file.write_text("{not valid json", encoding="utf-8")
+        scanner = WorkflowScanner()
+        models = scanner.extract_models_from_workflow(str(bad_file))
+        assert models == []
+
+    def test_file_not_found_returns_empty_list(self, tmp_path):
+        """Missing file returns an empty list (not an exception)."""
+        scanner = WorkflowScanner()
+        models = scanner.extract_models_from_workflow(str(tmp_path / "ghost.json"))
+        assert models == []
+
+    def test_non_model_extensions_ignored(self, tmp_path):
+        """Strings with non-model extensions in widgets_values are not extracted."""
+        workflow = {
+            "nodes": [
+                {
+                    "id": 1,
+                    "type": "CheckpointLoaderSimple",
+                    "widgets_values": ["readme.txt", "config.yaml", 42, True],
+                    "inputs": {},
+                }
+            ]
+        }
+        path = _write_workflow(tmp_path / "wf.json", workflow)
+        scanner = WorkflowScanner()
+        models = scanner.extract_models_from_workflow(path)
+        assert models == []
+
+    def test_return_node_count_flag(self, tmp_path, simple_workflow):
+        """return_node_count=True returns a (models, count) tuple."""
+        path = _write_workflow(tmp_path / "wf.json", simple_workflow)
+        scanner = WorkflowScanner()
+        result = scanner.extract_models_from_workflow(path, return_node_count=True)
+        assert isinstance(result, tuple)
+        models, count = result
+        # simple_workflow has 2 nodes
+        assert count == 2
+        assert len(models) == 1
+
+    def test_return_node_types_flag(self, tmp_path, complex_workflow):
+        """return_node_types=True returns a (models, count, node_types) tuple."""
+        path = _write_workflow(tmp_path / "wf.json", complex_workflow)
+        scanner = WorkflowScanner()
+        models, count, node_types = scanner.extract_models_from_workflow(
+            path, return_node_types=True
+        )
+        assert "CheckpointLoaderSimple" in node_types
+        assert "LoraLoader" in node_types
+        assert "ControlNetLoader" in node_types
+
+    def test_embedding_token_extracted_from_prompt(self, tmp_path, embedding_workflow):
+        """embedding:<name> tokens in CLIPTextEncode prompts are extracted as embeddings type."""
+        path = _write_workflow(tmp_path / "wf.json", embedding_workflow)
+        scanner = WorkflowScanner()
+        models = scanner.extract_models_from_workflow(path)
+        embedding_types = [m for m in models if m.type == "embeddings"]
+        assert len(embedding_types) >= 1
+        filenames = [m.filename for m in embedding_types]
+        assert any("BadDream" in fn for fn in filenames)
+
+    def test_duplicate_embedding_not_extracted_twice(self, tmp_path):
+        """The same embedding referenced in two nodes is only extracted once."""
+        workflow = {
+            "nodes": [
+                {
+                    "id": 1,
+                    "type": "CLIPTextEncode",
+                    "widgets_values": ["embedding:MyEmbed positive"],
+                    "inputs": {},
+                },
+                {
+                    "id": 2,
+                    "type": "CLIPTextEncode",
+                    "widgets_values": ["embedding:MyEmbed negative"],
+                    "inputs": {},
+                },
+            ]
+        }
+        path = _write_workflow(tmp_path / "wf.json", workflow)
+        scanner = WorkflowScanner()
+        models = scanner.extract_models_from_workflow(path)
+        embedding_names = [m.filename for m in models if m.type == "embeddings"]
+        assert embedding_names.count("MyEmbed.pt") == 1
+
+    def test_model_reference_has_workflow_path(self, tmp_path, simple_workflow):
+        """ModelReference.workflow_path matches the path passed to the scanner."""
+        path = _write_workflow(tmp_path / "wf.json", simple_workflow)
+        scanner = WorkflowScanner()
+        models = scanner.extract_models_from_workflow(path)
+        assert models[0].workflow_path == path
+
+    def test_vae_loader_type_is_vae(self, tmp_path):
+        """VAELoader nodes produce ModelReferences of type 'vae'."""
+        workflow = {
+            "nodes": [
+                {
+                    "id": 1,
+                    "type": "VAELoader",
+                    "widgets_values": ["vae-ft-mse-840000-ema-pruned.safetensors"],
+                    "inputs": {},
+                }
+            ]
+        }
+        path = _write_workflow(tmp_path / "wf.json", workflow)
+        scanner = WorkflowScanner()
+        models = scanner.extract_models_from_workflow(path)
+        assert len(models) == 1
+        assert models[0].type == "vae"
+
+
+# ---------------------------------------------------------------------------
+# Test: validate_workflow
+# ---------------------------------------------------------------------------
+
+class TestValidateWorkflow:
+    def test_valid_workflow_passes(self, tmp_path, simple_workflow):
+        """A well-formed workflow reports is_valid=True with no errors."""
+        path = _write_workflow(tmp_path / "wf.json", simple_workflow)
+        scanner = WorkflowScanner()
+        result = scanner.validate_workflow(path)
+        assert result["is_valid"] is True
+        assert result["errors"] == []
+
+    def test_invalid_json_fails_validation(self, tmp_path):
+        """Malformed JSON sets is_valid=False and populates errors."""
+        bad = tmp_path / "bad.json"
+        bad.write_text("{ broken json }", encoding="utf-8")
+        scanner = WorkflowScanner()
+        result = scanner.validate_workflow(str(bad))
+        assert result["is_valid"] is False
+        assert len(result["errors"]) > 0
+
+    def test_stats_include_node_and_model_count(self, tmp_path, simple_workflow):
+        """validate_workflow stats dict includes node_count and model_count."""
+        path = _write_workflow(tmp_path / "wf.json", simple_workflow)
+        scanner = WorkflowScanner()
+        result = scanner.validate_workflow(path)
+        assert "node_count" in result["stats"]
+        assert "model_count" in result["stats"]
+        assert result["stats"]["node_count"] == 2
+        assert result["stats"]["model_count"] == 1


### PR DESCRIPTION
## **User description**
## Summary

Adds the first test suite to ComfyWatchman, which previously had zero tests.

## Changes

- **tests/\_\_init\_\_.py**: Package init (empty)
- **tests/conftest.py**: Shared pytest fixtures with realistic mock ComfyUI workflow data — simple, complex (checkpoint+lora+controlnet), empty, embedding, and file-backed variants using \	mp_path\
- **tests/test_scanner.py**: 25 unit tests covering:
  - \scan_workflows()\: specific paths, non-existent files, non-JSON files, directory scanning
  - \xtract_models_from_workflow()\: checkpoint/lora/controlnet/vae extraction, model type assignment, path prefix stripping, invalid JSON, file-not-found, non-model extensions, \eturn_node_count\/\eturn_node_types\ flags, embedding token extraction, deduplication, \workflow_path\ assignment
  - \alidate_workflow()\: valid workflow, invalid JSON, stats dict shape
- **tests/test_config.py**: 19 tests for \CopilotConfig\, \SearchConfig\, \DownloadConfig\, \StateConfig\ defaults and \model_type_mapping\ lookup

## Test Results

\\\
44 passed in 0.27s
\\\

All tests pass. No mocking required — scanner is exercised with real filesystem writes to \	mp_path\.


___

## **CodeAnt-AI Description**
**Add initial test coverage for workflow scanning and config defaults**

### What Changed
- Adds test coverage for workflow scanning with valid files, missing files, invalid files, and folder scans
- Verifies model extraction from workflows for checkpoints, LoRAs, ControlNets, VAEs, and embedded prompt tokens
- Confirms invalid workflows fail cleanly with errors and summary stats
- Checks config defaults and model type mapping values used by the app

### Impact
`✅ Fewer workflow scanning regressions`
`✅ Safer model detection in saved workflows`
`✅ Clearer validation results for broken files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
